### PR TITLE
Add DHCP discovery to config flow

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,26 +1,48 @@
 # The contents of this file is based on https://github.com/home-assistant/core/blob/dev/pyproject.toml
 
-target-version = "py312"
+target-version = "py310"
 
-[lint]
 select = [
-    "ALL",
+    "B007", # Loop control variable {name} not used within loop body
+    "B014", # Exception handler with duplicate exception
+    "C",  # complexity
+    "D",  # docstrings
+    "E",  # pycodestyle
+    "F",  # pyflakes/autoflake
+    "ICN001", # import concentions; {name} should be imported as {asname}
+    "PGH004",  # Use specific rule codes when using noqa
+    "PLC0414", # Useless import alias. Import alias does not rename original package.
+    "SIM105", # Use contextlib.suppress({exception}) instead of try-except-pass
+    "SIM117", # Merge with-statements that use the same scope
+    "SIM118", # Use {key} in {dict} instead of {key} in {dict}.keys()
+    "SIM201", # Use {left} != {right} instead of not {left} == {right}
+    "SIM212", # Use {a} if {a} else {b} instead of {b} if not {a} else {a}
+    "SIM300", # Yoda conditions. Use 'age == 42' instead of '42 == age'.
+    "SIM401", # Use get from dict with default instead of an if block
+    "T20",  # flake8-print
+    "TRY004", # Prefer TypeError exception for invalid type
+    "RUF006", # Store a reference to the return value of asyncio.create_task
+    "UP",  # pyupgrade
+    "W",  # pycodestyle
 ]
 
 ignore = [
-    "ANN101", # Missing type annotation for `self` in method
-    "ANN401", # Dynamically typed expressions (typing.Any) are disallowed
-    "D203", # no-blank-line-before-class (incompatible with formatter)
-    "D212", # multi-line-summary-first-line (incompatible with formatter)
-    "COM812", # incompatible with formatter
-    "ISC001", # incompatible with formatter
+    "D202",  # No blank lines allowed after function docstring
+    "D203",  # 1 blank line required before class docstring
+    "D213",  # Multi-line docstring summary should start at the second line
+    "D404",  # First word of the docstring should not be This
+    "D406",  # Section name should end with a newline
+    "D407",  # Section name underlining
+    "D411",  # Missing blank line before section
+    "E501",  # line too long
+    "E731",  # do not assign a lambda expression, use a def
 ]
 
-[lint.flake8-pytest-style]
+[flake8-pytest-style]
 fixture-parentheses = false
 
-[lint.pyupgrade]
+[pyupgrade]
 keep-runtime-typing = true
 
-[lint.mccabe]
+[mccabe]
 max-complexity = 25

--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -11,6 +11,8 @@ logger:
   logs:
     custom_components.nintendo_wiiu_ristretto: debug
     python_wiiu_ristretto: debug
+    aiodhcpwatcher: debug
+    scapy: debug
 
 # Enable VSCode debugging
 debugpy:

--- a/custom_components/nintendo_wiiu_ristretto/__init__.py
+++ b/custom_components/nintendo_wiiu_ristretto/__init__.py
@@ -6,7 +6,12 @@ from homeassistant.core import HomeAssistant
 
 from .coordinator import WiiUCoordinator
 
-PLATFORMS = [Platform.BUTTON, Platform.MEDIA_PLAYER, Platform.SENSOR, Platform.BINARY_SENSOR]
+PLATFORMS = [
+    Platform.BUTTON,
+    Platform.MEDIA_PLAYER,
+    Platform.SENSOR,
+    Platform.BINARY_SENSOR,
+]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -24,14 +29,12 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Entry unloading."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
+
 async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Migrate entry."""
     if entry.version == 1:
         # Migrate from version 1 to version 2
         hass.config_entries.async_update_entry(
-            entry,
-            data=entry.data,
-            unique_id=entry.data[CONF_IP_ADDRESS],
-            version=2
+            entry, data=entry.data, unique_id=entry.data[CONF_IP_ADDRESS], version=2
         )
     return True

--- a/custom_components/nintendo_wiiu_ristretto/__init__.py
+++ b/custom_components/nintendo_wiiu_ristretto/__init__.py
@@ -1,7 +1,7 @@
 """Initialization."""
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform
+from homeassistant.const import CONF_IP_ADDRESS, Platform
 from homeassistant.core import HomeAssistant
 
 from .coordinator import WiiUCoordinator
@@ -23,3 +23,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Entry unloading."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Migrate entry."""
+    if entry.version == 1:
+        # Migrate from version 1 to version 2
+        hass.config_entries.async_update_entry(
+            entry,
+            data=entry.data,
+            unique_id=entry.data[CONF_IP_ADDRESS],
+            version=2
+        )
+    return True

--- a/custom_components/nintendo_wiiu_ristretto/binary_sensor.py
+++ b/custom_components/nintendo_wiiu_ristretto/binary_sensor.py
@@ -19,14 +19,16 @@ class WiiUBinarySensorEntityDescription(BinarySensorEntityDescription):
 
     is_on_fn: Callable[[WiiUEntity], None] = lambda: None
 
+
 ENTITY_DESCRIPTIONS = [
     WiiUBinarySensorEntityDescription(
         key="gamepad_charging",
         device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
         name="Gamepad Charging",
-        is_on_fn=lambda entity: entity.coordinator.gamepad_charging
+        is_on_fn=lambda entity: entity.coordinator.gamepad_charging,
     )
 ]
+
 
 async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
     """Set up the button platform."""
@@ -40,10 +42,15 @@ async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
         ]
     )
 
+
 class GenericWiiUBinarySensor(WiiUEntity, BinarySensorEntity):
     """A generic Wii U binary sensor."""
 
-    def __init__(self, coordinator: WiiUCoordinator, description: WiiUBinarySensorEntityDescription):
+    def __init__(
+        self,
+        coordinator: WiiUCoordinator,
+        description: WiiUBinarySensorEntityDescription,
+    ):
         """Initialize a binary sensor."""
         super().__init__(coordinator)
         self.coordinator = coordinator

--- a/custom_components/nintendo_wiiu_ristretto/button.py
+++ b/custom_components/nintendo_wiiu_ristretto/button.py
@@ -39,8 +39,8 @@ ENTITY_DESCRIPTIONS: list[WiiUButtonEntityDescription] = [
         key="launch_vwii",
         name="Launch vWii",
         press_fn=lambda entity: entity.coordinator.wii.async_launch_vwii_menu,
-        icon="mdi:nintendo-wii"
-    )
+        icon="mdi:nintendo-wii",
+    ),
 ]
 
 

--- a/custom_components/nintendo_wiiu_ristretto/config_flow.py
+++ b/custom_components/nintendo_wiiu_ristretto/config_flow.py
@@ -35,23 +35,25 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
     VERSION = 2
     _dhcp_discovery_info = None
 
-    async def async_step_dhcp(self, discovery_info: DhcpServiceInfo) -> ConfigFlowResult:
+    async def async_step_dhcp(
+        self, discovery_info: DhcpServiceInfo
+    ) -> ConfigFlowResult:
         """Process initial DHCP discovery step."""
         self._dhcp_discovery_info = discovery_info
         await self.async_set_unique_id(discovery_info.ip)
         self._abort_if_unique_id_configured()
         registry = er.async_get(self.hass)
 
-        if registry.async_get_entity_id(
-            MP_DOMAIN, DOMAIN, discovery_info.ip
-        ) is not None:
+        if (
+            registry.async_get_entity_id(MP_DOMAIN, DOMAIN, discovery_info.ip)
+            is not None
+        ):
             raise AbortFlow("already_configured")
         return await self.async_step_dhcp_confirm()
 
     async def async_step_dhcp_confirm(
-            self,
-            user_input: dict[str, Any] | None = None
-        ) -> ConfigFlowResult:
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         """DHCP Discovery configuration."""
         if user_input is not None:
             return self.async_create_entry(title=user_input[CONF_NAME], data=user_input)
@@ -59,17 +61,14 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             CONF_IP_ADDRESS: self._dhcp_discovery_info.ip,
             CONF_PORT: 8572,
             CONF_TIMEOUT: DEFAULT_TIMEOUT,
-            CONF_SCAN_INTERVAL: DEFAULT_UPDATE_INTERVAL
+            CONF_SCAN_INTERVAL: DEFAULT_UPDATE_INTERVAL,
         }
         return self.async_show_form(
             step_id="dhcp_confirm",
             data_schema=self.add_suggested_values_to_schema(
-                data_schema=SCHEMA,
-                suggested_values=configuration
+                data_schema=SCHEMA, suggested_values=configuration
             ),
-            description_placeholders={
-                CONF_IP_ADDRESS: self._dhcp_discovery_info.ip
-            }
+            description_placeholders={CONF_IP_ADDRESS: self._dhcp_discovery_info.ip},
         )
 
     async def async_step_user(

--- a/custom_components/nintendo_wiiu_ristretto/config_flow.py
+++ b/custom_components/nintendo_wiiu_ristretto/config_flow.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 import voluptuous as vol
+from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import (
     CONF_IP_ADDRESS,
@@ -11,15 +12,18 @@ from homeassistant.const import (
     CONF_SCAN_INTERVAL,
     CONF_TIMEOUT,
 )
+from homeassistant.data_entry_flow import AbortFlow
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
-from .const import DEFAULT_TIMEOUT, DOMAIN
+from .const import DEFAULT_TIMEOUT, DEFAULT_UPDATE_INTERVAL, DOMAIN
 
 SCHEMA = vol.Schema(
     {
         vol.Required(CONF_IP_ADDRESS): str,
         vol.Required(CONF_PORT, default=8572): int,
         vol.Optional(CONF_NAME, default="Wii U"): str,
-        vol.Optional(CONF_SCAN_INTERVAL, default=10): int,
+        vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_UPDATE_INTERVAL): int,
         vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): int,
     }
 )
@@ -28,7 +32,45 @@ SCHEMA = vol.Schema(
 class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
     """Handle flow."""
 
-    VERSION = 1
+    VERSION = 2
+    _dhcp_discovery_info = None
+
+    async def async_step_dhcp(self, discovery_info: DhcpServiceInfo) -> ConfigFlowResult:
+        """Process initial DHCP discovery step."""
+        self._dhcp_discovery_info = discovery_info
+        await self.async_set_unique_id(discovery_info.ip)
+        self._abort_if_unique_id_configured()
+        registry = er.async_get(self.hass)
+
+        if registry.async_get_entity_id(
+            MP_DOMAIN, DOMAIN, discovery_info.ip
+        ) is not None:
+            raise AbortFlow("already_configured")
+        return await self.async_step_dhcp_confirm()
+
+    async def async_step_dhcp_confirm(
+            self,
+            user_input: dict[str, Any] | None = None
+        ) -> ConfigFlowResult:
+        """DHCP Discovery configuration."""
+        if user_input is not None:
+            return self.async_create_entry(title=user_input[CONF_NAME], data=user_input)
+        configuration = {
+            CONF_IP_ADDRESS: self._dhcp_discovery_info.ip,
+            CONF_PORT: 8572,
+            CONF_TIMEOUT: DEFAULT_TIMEOUT,
+            CONF_SCAN_INTERVAL: DEFAULT_UPDATE_INTERVAL
+        }
+        return self.async_show_form(
+            step_id="dhcp_confirm",
+            data_schema=self.add_suggested_values_to_schema(
+                data_schema=SCHEMA,
+                suggested_values=configuration
+            ),
+            description_placeholders={
+                CONF_IP_ADDRESS: self._dhcp_discovery_info.ip
+            }
+        )
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -36,6 +78,8 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         """User setup step."""
         errors = {}
         if user_input is not None:
+            await self.async_set_unique_id(user_input[CONF_IP_ADDRESS])
+            self._abort_if_unique_id_configured()
             return self.async_create_entry(title=user_input[CONF_NAME], data=user_input)
 
         return self.async_show_form(

--- a/custom_components/nintendo_wiiu_ristretto/coordinator.py
+++ b/custom_components/nintendo_wiiu_ristretto/coordinator.py
@@ -95,10 +95,10 @@ class WiiUCoordinator(DataUpdateCoordinator):
                     self.gamepad_battery = 100
                 else:
                     self.gamepad_charging = False
-                    self.gamepad_battery = ((self.gamepad_battery-1)/5)*100
+                    self.gamepad_battery = ((self.gamepad_battery - 1) / 5) * 100
             self.is_on = True
         except ClientOSError:
-            pass # silently discard connection reset errors as this can happen when switching source
+            pass  # silently discard connection reset errors as this can happen when switching source
         except (AsyncTimeoutError, ConnectionError):
             self.is_on = False
         except Exception as e:

--- a/custom_components/nintendo_wiiu_ristretto/manifest.json
+++ b/custom_components/nintendo_wiiu_ristretto/manifest.json
@@ -3,288 +3,384 @@
     "name": "Nintendo Wii U (with Ristretto)",
     "config_flow": true,
     "codeowners": [],
-    "dependencies": [],
+    "dependencies": [
+        "dhcp"
+    ],
     "dhcp": [
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "0009BF*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "001656*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "0017AB*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "001A9D*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "001AE9*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "001B7A*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "001BEA*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "001CBE*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "001DBC*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "001E35*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "001EA9*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "001F32*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "001FC5*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "002147*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "0021BD*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "00224C*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "0022AA*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "0022D7*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "002331*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "0023CC*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "00241E*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "002444*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "0024F3*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "0025A0*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "002659*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "002709*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "182A7B*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "1C4586*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "200BCF*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "201C3A*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "28CF51*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "2C10C1*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "342FBD*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "34AF2C*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "3CA9AB*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "40D28A*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "40F407*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "483177*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "48A5E7*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "48F1EB*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "50236D*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "582F40*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "58B03E*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "58BDA3*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "5C0CE6*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "5C521E*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "601AC7*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "606BFF*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "64B5C6*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "702C09*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "7048F7*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "70F088*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "748469*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "74F9CA*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "7820A5*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "78818C*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "78A2A0*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "7CBB8A*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "80D2E5*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "8C56C5*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "8CCDE8*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "904528*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "9458CB*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "98415C*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "98B6E9*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "98E255*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "98E8FA*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "9CE635*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "A438CC*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "A45C27*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "A4C0E1*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "ACFAE4*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "B88AEC*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "B8AE6E*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "B87826*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "BC744B*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "BC9EBB*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "BCCE25*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "CC5B31*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "CC9E00*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "CCFB65*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "D05509*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "D4F057*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "D86BF7*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "DC68EB*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "DCCD18*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "E00C7F*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "E0E751*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "E0EFBF*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "E0F6B5*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "E84ECE*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "E8A0CD*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "E8DA20*"
         },
         {
+            "hostname": "Nintendo Wii U",
             "macaddress": "ECC40D*"
         }
     ],

--- a/custom_components/nintendo_wiiu_ristretto/manifest.json
+++ b/custom_components/nintendo_wiiu_ristretto/manifest.json
@@ -4,6 +4,11 @@
     "config_flow": true,
     "codeowners": [],
     "dependencies": [],
+    "dhcp": [
+        {
+            "macaddress": "34AF2C*"
+        }
+    ],
     "iot_class": "local_polling",
     "loggers": [
         "python_wiiu_ristretto"

--- a/custom_components/nintendo_wiiu_ristretto/manifest.json
+++ b/custom_components/nintendo_wiiu_ristretto/manifest.json
@@ -6,7 +6,286 @@
     "dependencies": [],
     "dhcp": [
         {
+            "macaddress": "0009BF*"
+        },
+        {
+            "macaddress": "001656*"
+        },
+        {
+            "macaddress": "0017AB*"
+        },
+        {
+            "macaddress": "001A9D*"
+        },
+        {
+            "macaddress": "001AE9*"
+        },
+        {
+            "macaddress": "001B7A*"
+        },
+        {
+            "macaddress": "001BEA*"
+        },
+        {
+            "macaddress": "001CBE*"
+        },
+        {
+            "macaddress": "001DBC*"
+        },
+        {
+            "macaddress": "001E35*"
+        },
+        {
+            "macaddress": "001EA9*"
+        },
+        {
+            "macaddress": "001F32*"
+        },
+        {
+            "macaddress": "001FC5*"
+        },
+        {
+            "macaddress": "002147*"
+        },
+        {
+            "macaddress": "0021BD*"
+        },
+        {
+            "macaddress": "00224C*"
+        },
+        {
+            "macaddress": "0022AA*"
+        },
+        {
+            "macaddress": "0022D7*"
+        },
+        {
+            "macaddress": "002331*"
+        },
+        {
+            "macaddress": "0023CC*"
+        },
+        {
+            "macaddress": "00241E*"
+        },
+        {
+            "macaddress": "002444*"
+        },
+        {
+            "macaddress": "0024F3*"
+        },
+        {
+            "macaddress": "0025A0*"
+        },
+        {
+            "macaddress": "002659*"
+        },
+        {
+            "macaddress": "002709*"
+        },
+        {
+            "macaddress": "182A7B*"
+        },
+        {
+            "macaddress": "1C4586*"
+        },
+        {
+            "macaddress": "200BCF*"
+        },
+        {
+            "macaddress": "201C3A*"
+        },
+        {
+            "macaddress": "28CF51*"
+        },
+        {
+            "macaddress": "2C10C1*"
+        },
+        {
+            "macaddress": "342FBD*"
+        },
+        {
             "macaddress": "34AF2C*"
+        },
+        {
+            "macaddress": "3CA9AB*"
+        },
+        {
+            "macaddress": "40D28A*"
+        },
+        {
+            "macaddress": "40F407*"
+        },
+        {
+            "macaddress": "483177*"
+        },
+        {
+            "macaddress": "48A5E7*"
+        },
+        {
+            "macaddress": "48F1EB*"
+        },
+        {
+            "macaddress": "50236D*"
+        },
+        {
+            "macaddress": "582F40*"
+        },
+        {
+            "macaddress": "58B03E*"
+        },
+        {
+            "macaddress": "58BDA3*"
+        },
+        {
+            "macaddress": "5C0CE6*"
+        },
+        {
+            "macaddress": "5C521E*"
+        },
+        {
+            "macaddress": "601AC7*"
+        },
+        {
+            "macaddress": "606BFF*"
+        },
+        {
+            "macaddress": "64B5C6*"
+        },
+        {
+            "macaddress": "702C09*"
+        },
+        {
+            "macaddress": "7048F7*"
+        },
+        {
+            "macaddress": "70F088*"
+        },
+        {
+            "macaddress": "748469*"
+        },
+        {
+            "macaddress": "74F9CA*"
+        },
+        {
+            "macaddress": "7820A5*"
+        },
+        {
+            "macaddress": "78818C*"
+        },
+        {
+            "macaddress": "78A2A0*"
+        },
+        {
+            "macaddress": "7CBB8A*"
+        },
+        {
+            "macaddress": "80D2E5*"
+        },
+        {
+            "macaddress": "8C56C5*"
+        },
+        {
+            "macaddress": "8CCDE8*"
+        },
+        {
+            "macaddress": "904528*"
+        },
+        {
+            "macaddress": "9458CB*"
+        },
+        {
+            "macaddress": "98415C*"
+        },
+        {
+            "macaddress": "98B6E9*"
+        },
+        {
+            "macaddress": "98E255*"
+        },
+        {
+            "macaddress": "98E8FA*"
+        },
+        {
+            "macaddress": "9CE635*"
+        },
+        {
+            "macaddress": "A438CC*"
+        },
+        {
+            "macaddress": "A45C27*"
+        },
+        {
+            "macaddress": "A4C0E1*"
+        },
+        {
+            "macaddress": "ACFAE4*"
+        },
+        {
+            "macaddress": "B88AEC*"
+        },
+        {
+            "macaddress": "B8AE6E*"
+        },
+        {
+            "macaddress": "B87826*"
+        },
+        {
+            "macaddress": "BC744B*"
+        },
+        {
+            "macaddress": "BC9EBB*"
+        },
+        {
+            "macaddress": "BCCE25*"
+        },
+        {
+            "macaddress": "CC5B31*"
+        },
+        {
+            "macaddress": "CC9E00*"
+        },
+        {
+            "macaddress": "CCFB65*"
+        },
+        {
+            "macaddress": "D05509*"
+        },
+        {
+            "macaddress": "D4F057*"
+        },
+        {
+            "macaddress": "D86BF7*"
+        },
+        {
+            "macaddress": "DC68EB*"
+        },
+        {
+            "macaddress": "DCCD18*"
+        },
+        {
+            "macaddress": "E00C7F*"
+        },
+        {
+            "macaddress": "E0E751*"
+        },
+        {
+            "macaddress": "E0EFBF*"
+        },
+        {
+            "macaddress": "E0F6B5*"
+        },
+        {
+            "macaddress": "E84ECE*"
+        },
+        {
+            "macaddress": "E8A0CD*"
+        },
+        {
+            "macaddress": "E8DA20*"
+        },
+        {
+            "macaddress": "ECC40D*"
         }
     ],
     "iot_class": "local_polling",

--- a/custom_components/nintendo_wiiu_ristretto/sensor.py
+++ b/custom_components/nintendo_wiiu_ristretto/sensor.py
@@ -30,7 +30,7 @@ ENTITY_DESCRIPTIONS: list[WiiUSensorEntityDescription] = [
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.BATTERY,
         value_fn=lambda entity: entity.coordinator.gamepad_battery,
-        suggested_display_precision=0
+        suggested_display_precision=0,
     )
 ]
 

--- a/custom_components/nintendo_wiiu_ristretto/translations/en.json
+++ b/custom_components/nintendo_wiiu_ristretto/translations/en.json
@@ -10,6 +10,16 @@
                     "scan_interval": "Update Interval",
                     "timeout": "Timeout"
                 }
+            },
+            "dhcp_confirm": {
+                "description": "Configuring device {ip_address}\n\nMake sure your console is on, and Ristretto is running. Be aware currently powering on the console from powered off state is not available, nor is requests when ProcUI is in the foreground (when applets are open). Requests while an applet is open can cause the console to softlock or crash.",
+                "data": {
+                    "ip_address": "IP Address",
+                    "port": "Ristretto Port",
+                    "name": "Device Name",
+                    "scan_interval": "Update Interval",
+                    "timeout": "Timeout"
+                }
             }
         },
         "error": {
@@ -18,7 +28,7 @@
             "unknown": "Unknown error occurred."
         },
         "abort": {
-            "already_configured": "This entry is already configured."
+            "already_configured": "This device is already configured."
         }
     }
 }


### PR DESCRIPTION
Simple PR this time..

Adds autodiscovery via DHCP to the config flow and updates translations.

To ensure duplicate devices are not added, the config entry unique ID is set to the IP address of the device. Perhaps we can do mac address instead if Ristretto could output that?

In theory we can change the IP address of the existing config entry if it were to change for some reason if we could capture the MAC.

Also - as a side benefit I've updated ruff config to fix the failed CI pipeline and reformatted the code base according to the new rules.

EDIT: Added the list of mac addresses from discord... These probably could do with being validated though....