### PR TITLE
Implement device triggers for Nintendo Wii U

### DIFF
--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -16,3 +16,5 @@ logger:
 debugpy:
   start: true
   wait: true
+
+automation: !include automations.yaml

--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -16,5 +16,3 @@ logger:
 debugpy:
   start: true
   wait: true
-
-automation: !include automations.yaml

--- a/custom_components/nintendo_wiiu_ristretto/__init__.py
+++ b/custom_components/nintendo_wiiu_ristretto/__init__.py
@@ -6,7 +6,12 @@ from homeassistant.core import HomeAssistant
 
 from .coordinator import WiiUCoordinator
 
-PLATFORMS = [Platform.BUTTON, Platform.MEDIA_PLAYER, Platform.SENSOR, Platform.BINARY_SENSOR]
+PLATFORMS = [
+    Platform.BUTTON,
+    Platform.MEDIA_PLAYER,
+    Platform.SENSOR,
+    Platform.BINARY_SENSOR,
+]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/nintendo_wiiu_ristretto/binary_sensor.py
+++ b/custom_components/nintendo_wiiu_ristretto/binary_sensor.py
@@ -8,6 +8,8 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 
 from .coordinator import WiiUCoordinator
 from .entity import WiiUEntity
@@ -19,16 +21,22 @@ class WiiUBinarySensorEntityDescription(BinarySensorEntityDescription):
 
     is_on_fn: Callable[[WiiUEntity], None] = lambda: None
 
+
 ENTITY_DESCRIPTIONS = [
     WiiUBinarySensorEntityDescription(
         key="gamepad_charging",
         device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
         name="Gamepad Charging",
-        is_on_fn=lambda entity: entity.coordinator.gamepad_charging
+        is_on_fn=lambda entity: entity.coordinator.gamepad_charging,
     )
 ]
 
-async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
+
+async def async_setup_entry(
+    hass: HomeAssistant,  # noqa: ARG001
+    config_entry: ConfigEntry,
+    async_add_entities: Callable[[list[BinarySensorEntity]], None],
+) -> None:
     """Set up the button platform."""
     coordinator = config_entry.runtime_data
     if not isinstance(coordinator, WiiUCoordinator):
@@ -40,10 +48,15 @@ async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
         ]
     )
 
+
 class GenericWiiUBinarySensor(WiiUEntity, BinarySensorEntity):
     """A generic Wii U binary sensor."""
 
-    def __init__(self, coordinator: WiiUCoordinator, description: WiiUBinarySensorEntityDescription):
+    def __init__(
+        self,
+        coordinator: WiiUCoordinator,
+        description: WiiUBinarySensorEntityDescription,
+    ) -> None:
         """Initialize a binary sensor."""
         super().__init__(coordinator)
         self.coordinator = coordinator

--- a/custom_components/nintendo_wiiu_ristretto/button.py
+++ b/custom_components/nintendo_wiiu_ristretto/button.py
@@ -8,7 +8,9 @@ from homeassistant.components.button import (
     ButtonEntity,
     ButtonEntityDescription,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
 
 from .coordinator import WiiUCoordinator
 from .entity import WiiUEntity
@@ -39,12 +41,16 @@ ENTITY_DESCRIPTIONS: list[WiiUButtonEntityDescription] = [
         key="launch_vwii",
         name="Launch vWii",
         press_fn=lambda entity: entity.coordinator.wii.async_launch_vwii_menu,
-        icon="mdi:nintendo-wii"
-    )
+        icon="mdi:nintendo-wii",
+    ),
 ]
 
 
-async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
+async def async_setup_entry(
+    hass: HomeAssistant,  # noqa: ARG001
+    config_entry: ConfigEntry,
+    async_add_entities: Callable[[list[ButtonEntity]], None],
+) -> None:
     """Set up the button platform."""
     coordinator = config_entry.runtime_data
     if not isinstance(coordinator, WiiUCoordinator):
@@ -76,3 +82,7 @@ class GenericWiiUButton(WiiUEntity, ButtonEntity):
     async def async_press(self) -> None:
         """Perform a given action on press."""
         await self.entity_description.press_fn(self)()
+
+    def press(self) -> None:
+        """Perform a given action on press synchronously."""
+        self.hass.async_create_task(self.async_press())

--- a/custom_components/nintendo_wiiu_ristretto/coordinator.py
+++ b/custom_components/nintendo_wiiu_ristretto/coordinator.py
@@ -2,7 +2,6 @@
 
 import json
 import logging
-from asyncio import TimeoutError as AsyncTimeoutError
 from datetime import timedelta
 
 from aiohttp import ClientOSError
@@ -95,11 +94,12 @@ class WiiUCoordinator(DataUpdateCoordinator):
                     self.gamepad_battery = 100
                 else:
                     self.gamepad_charging = False
-                    self.gamepad_battery = ((self.gamepad_battery-1)/5)*100
+                    self.gamepad_battery = ((self.gamepad_battery - 1) / 5) * 100
             self.is_on = True
         except ClientOSError:
-            pass # silently discard connection reset errors as this can happen when switching source
-        except (AsyncTimeoutError, ConnectionError):
+            # discard connection errors
+            pass
+        except (TimeoutError, ConnectionError):
             self.is_on = False
         except Exception as e:
             _LOGGER.exception("Error updating data", exc_info=e)

--- a/custom_components/nintendo_wiiu_ristretto/device_trigger.py
+++ b/custom_components/nintendo_wiiu_ristretto/device_trigger.py
@@ -2,16 +2,15 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import voluptuous as vol
 from homeassistant.components.device_automation import (
     DEVICE_TRIGGER_BASE_SCHEMA,
     InvalidDeviceAutomationConfig,
 )
 from homeassistant.const import CONF_DEVICE_ID, CONF_PLATFORM, CONF_TYPE
-from homeassistant.core import CALLBACK_TYPE, HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
-from homeassistant.helpers.typing import ConfigType
 
 from . import trigger
 from .const import DOMAIN
@@ -22,12 +21,18 @@ from .helpers import (
 from .triggers.turn_on import PLATFORM_TYPE as TURN_ON_PLATFORM_TYPE
 from .triggers.turn_on import async_get_turn_on_trigger
 
+if TYPE_CHECKING:
+    from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+    from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
+    from homeassistant.helpers.typing import ConfigType
+
 TRIGGER_TYPES = {TURN_ON_PLATFORM_TYPE}
 TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
     {
         vol.Required(CONF_TYPE): vol.In(TRIGGER_TYPES),
     }
 )
+
 
 async def async_validate_trigger_config(
     hass: HomeAssistant, config: ConfigType
@@ -45,11 +50,13 @@ async def async_validate_trigger_config(
 
     return config
 
+
 async def async_get_triggers(
     _hass: HomeAssistant, device_id: str
 ) -> list[dict[str, str]]:
     """List device triggers for device."""
     return [async_get_turn_on_trigger(device_id)]
+
 
 async def async_attach_trigger(
     hass: HomeAssistant,

--- a/custom_components/nintendo_wiiu_ristretto/device_trigger.py
+++ b/custom_components/nintendo_wiiu_ristretto/device_trigger.py
@@ -1,0 +1,77 @@
+"""Nintendo WiiU Ristretto device trigger."""
+
+from __future__ import annotations
+
+import voluptuous as vol
+from homeassistant.components.device_automation import (
+    DEVICE_TRIGGER_BASE_SCHEMA,
+    InvalidDeviceAutomationConfig,
+)
+from homeassistant.const import CONF_DEVICE_ID, CONF_PLATFORM, CONF_TYPE
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
+from homeassistant.helpers.typing import ConfigType
+
+from . import trigger
+from .const import DOMAIN
+from .helpers import (
+    async_get_client_by_device_entry,
+    async_get_device_entry_by_device_id,
+)
+from .triggers.turn_on import PLATFORM_TYPE as TURN_ON_PLATFORM_TYPE
+from .triggers.turn_on import async_get_turn_on_trigger
+
+TRIGGER_TYPES = {TURN_ON_PLATFORM_TYPE}
+TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_TYPE): vol.In(TRIGGER_TYPES),
+    }
+)
+
+async def async_validate_trigger_config(
+    hass: HomeAssistant, config: ConfigType
+) -> ConfigType:
+    """Validate config."""
+    config = TRIGGER_SCHEMA(config)
+
+    if config[CONF_TYPE] == TURN_ON_PLATFORM_TYPE:
+        device_id = config[CONF_DEVICE_ID]
+        try:
+            device = async_get_device_entry_by_device_id(hass, device_id)
+            async_get_client_by_device_entry(hass, device)
+        except ValueError as err:
+            raise InvalidDeviceAutomationConfig(err) from err
+
+    return config
+
+async def async_get_triggers(
+    _hass: HomeAssistant, device_id: str
+) -> list[dict[str, str]]:
+    """List device triggers for device."""
+    return [async_get_turn_on_trigger(device_id)]
+
+async def async_attach_trigger(
+    hass: HomeAssistant,
+    config: ConfigType,
+    action: TriggerActionType,
+    trigger_info: TriggerInfo,
+) -> CALLBACK_TYPE:
+    """Attach a trigger."""
+    if (trigger_type := config[CONF_TYPE]) == TURN_ON_PLATFORM_TYPE:
+        trigger_config = {
+            CONF_PLATFORM: trigger_type,
+            CONF_DEVICE_ID: config[CONF_DEVICE_ID],
+        }
+        trigger_config = await trigger.async_validate_trigger_config(
+            hass, trigger_config
+        )
+        return await trigger.async_attach_trigger(
+            hass, trigger_config, action, trigger_info
+        )
+
+    raise HomeAssistantError(
+        translation_domain=DOMAIN,
+        translation_key="unhandled_trigger_type",
+        translation_placeholders={"trigger_type": trigger_type},
+    )

--- a/custom_components/nintendo_wiiu_ristretto/entity.py
+++ b/custom_components/nintendo_wiiu_ristretto/entity.py
@@ -3,12 +3,10 @@
 import logging
 
 from homeassistant.const import CONF_NAME
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.trigger import PluggableAction
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
 from .coordinator import WiiUCoordinator
 from .triggers.turn_on import async_get_turn_on_trigger
 

--- a/custom_components/nintendo_wiiu_ristretto/entity.py
+++ b/custom_components/nintendo_wiiu_ristretto/entity.py
@@ -1,11 +1,18 @@
 """Base entity for a Wii U device."""
 
+import logging
+
 from homeassistant.const import CONF_NAME
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.trigger import PluggableAction
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from custom_components.nintendo_wiiu_ristretto.coordinator import WiiUCoordinator
+from .const import DOMAIN
+from .coordinator import WiiUCoordinator
+from .triggers.turn_on import async_get_turn_on_trigger
 
+LOGGER = logging.getLogger(__name__)
 
 class WiiUEntity(CoordinatorEntity[WiiUCoordinator]):
     """Base entity for a Wii U device."""
@@ -13,6 +20,7 @@ class WiiUEntity(CoordinatorEntity[WiiUCoordinator]):
     def __init__(self, coordinator: WiiUCoordinator) -> None:
         """Initialize entity and coordinator."""
         super().__init__(coordinator=coordinator)
+        self._turn_on_action = PluggableAction(self.async_write_ha_state)
 
     @property
     def unique_id(self) -> str:
@@ -33,3 +41,13 @@ class WiiUEntity(CoordinatorEntity[WiiUCoordinator]):
             serial_number=self.coordinator.serial,
             sw_version=self.coordinator.sw_version,
         )
+
+    async def async_added_to_hass(self) -> None:
+        """Add device triggers."""
+        await super().async_added_to_hass()
+        if (entry := self.registry_entry) and entry.device_id:
+            self.async_on_remove(
+                self._turn_on_action.async_register(
+                    self.hass, async_get_turn_on_trigger(entry.device_id)
+                )
+            )

--- a/custom_components/nintendo_wiiu_ristretto/entity.py
+++ b/custom_components/nintendo_wiiu_ristretto/entity.py
@@ -12,6 +12,7 @@ from .triggers.turn_on import async_get_turn_on_trigger
 
 LOGGER = logging.getLogger(__name__)
 
+
 class WiiUEntity(CoordinatorEntity[WiiUCoordinator]):
     """Base entity for a Wii U device."""
 

--- a/custom_components/nintendo_wiiu_ristretto/helpers.py
+++ b/custom_components/nintendo_wiiu_ristretto/helpers.py
@@ -2,14 +2,19 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.device_registry import DeviceEntry
 
 from .const import DOMAIN
-from .coordinator import WiiUCoordinator
+
+if TYPE_CHECKING:
+    from homeassistant.helpers.device_registry import DeviceEntry
+
+    from .coordinator import WiiUCoordinator
 
 
 @callback
@@ -23,9 +28,11 @@ def async_get_device_entry_by_device_id(
     """
     device_reg = dr.async_get(hass)
     if (device := device_reg.async_get(device_id)) is None:
-        raise ValueError(f"Device {device_id} is not a valid {DOMAIN} device.")
+        msg = f"Device {device_id} is not a valid {DOMAIN} device."
+        raise ValueError(msg)
 
     return device
+
 
 @callback
 def async_get_device_id_from_entity_id(hass: HomeAssistant, entity_id: str) -> str:
@@ -42,9 +49,11 @@ def async_get_device_id_from_entity_id(hass: HomeAssistant, entity_id: str) -> s
         or entity_entry.device_id is None
         or entity_entry.platform != DOMAIN
     ):
-        raise ValueError(f"Entity {entity_id} is not a valid {DOMAIN} entity.")
+        msg = f"Entity {entity_id} is not a valid {DOMAIN} entity."
+        raise ValueError(msg)
 
     return entity_entry.device_id
+
 
 @callback
 def async_get_client_by_device_entry(
@@ -61,6 +70,5 @@ def async_get_client_by_device_entry(
         if entry and entry.domain == DOMAIN and entry.state is ConfigEntryState.LOADED:
             return entry.runtime_data
 
-    raise ValueError(
-        f"Device {device.id} is not from an existing {DOMAIN} config entry"
-    )
+    msg = f"Device {device.id} is not from an existing {DOMAIN} config entry"
+    raise ValueError(msg)

--- a/custom_components/nintendo_wiiu_ristretto/helpers.py
+++ b/custom_components/nintendo_wiiu_ristretto/helpers.py
@@ -1,0 +1,66 @@
+"""Helper functions for Nintendo WiiU Ristretto."""
+
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.device_registry import DeviceEntry
+
+from .const import DOMAIN
+from .coordinator import WiiUCoordinator
+
+
+@callback
+def async_get_device_entry_by_device_id(
+    hass: HomeAssistant, device_id: str
+) -> DeviceEntry:
+    """
+    Get Device Entry from Device Registry by device ID.
+
+    Raises ValueError if device ID is invalid.
+    """
+    device_reg = dr.async_get(hass)
+    if (device := device_reg.async_get(device_id)) is None:
+        raise ValueError(f"Device {device_id} is not a valid {DOMAIN} device.")
+
+    return device
+
+@callback
+def async_get_device_id_from_entity_id(hass: HomeAssistant, entity_id: str) -> str:
+    """
+    Get device ID from an entity ID.
+
+    Raises ValueError if entity or device ID is invalid.
+    """
+    ent_reg = er.async_get(hass)
+    entity_entry = ent_reg.async_get(entity_id)
+
+    if (
+        entity_entry is None
+        or entity_entry.device_id is None
+        or entity_entry.platform != DOMAIN
+    ):
+        raise ValueError(f"Entity {entity_id} is not a valid {DOMAIN} entity.")
+
+    return entity_entry.device_id
+
+@callback
+def async_get_client_by_device_entry(
+    hass: HomeAssistant, device: DeviceEntry
+) -> WiiUCoordinator:
+    """
+    Get WiiUCoordinator from Device Registry by device entry.
+
+    Raises ValueError if client is not found.
+    """
+    entry: WiiUCoordinator | None
+    for config_entry_id in device.config_entries:
+        entry = hass.config_entries.async_get_entry(config_entry_id)
+        if entry and entry.domain == DOMAIN and entry.state is ConfigEntryState.LOADED:
+            return entry.runtime_data
+
+    raise ValueError(
+        f"Device {device.id} is not from an existing {DOMAIN} config entry"
+    )

--- a/custom_components/nintendo_wiiu_ristretto/media_player.py
+++ b/custom_components/nintendo_wiiu_ristretto/media_player.py
@@ -38,7 +38,9 @@ class NintendoWiiUMediaPlayer(WiiUEntity, MediaPlayerEntity):
 
     _attr_icon = "mdi:nintendo-wiiu"
     _attr_supported_features = (
-        MediaPlayerEntityFeature.TURN_OFF | MediaPlayerEntityFeature.SELECT_SOURCE
+        MediaPlayerEntityFeature.TURN_OFF
+        | MediaPlayerEntityFeature.SELECT_SOURCE
+        | MediaPlayerEntityFeature.TURN_ON
     )
 
     def __init__(self, coordinator: WiiUCoordinator, name: str):
@@ -85,3 +87,9 @@ class NintendoWiiUMediaPlayer(WiiUEntity, MediaPlayerEntity):
         await self.coordinator.wii.async_shutdown()
         self.coordinator.is_on = False
         self.schedule_update_ha_state(force_refresh=True)
+
+    async def async_turn_on(self) -> None:
+        """Turn on the Wii U console."""
+        if self.coordinator.is_on:
+            return
+        await self._turn_on_action.async_run(self.hass, self._context)

--- a/custom_components/nintendo_wiiu_ristretto/media_player.py
+++ b/custom_components/nintendo_wiiu_ristretto/media_player.py
@@ -18,12 +18,11 @@ from custom_components.nintendo_wiiu_ristretto.entity import WiiUEntity
 
 
 async def async_setup_entry(
-    hass: HomeAssistant,
+    hass: HomeAssistant,  # noqa: ARG001
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Wii U media player entity."""
-    # TODO: Make list, handle devices being offline
     async_add_entities(
         [
             NintendoWiiUMediaPlayer(
@@ -33,7 +32,7 @@ async def async_setup_entry(
     )
 
 
-class NintendoWiiUMediaPlayer(WiiUEntity, MediaPlayerEntity):
+class NintendoWiiUMediaPlayer(WiiUEntity, MediaPlayerEntity):  # pylint: disable=W0223
     """Representation of a Wii U console."""
 
     _attr_icon = "mdi:nintendo-wiiu"
@@ -43,7 +42,7 @@ class NintendoWiiUMediaPlayer(WiiUEntity, MediaPlayerEntity):
         | MediaPlayerEntityFeature.TURN_ON
     )
 
-    def __init__(self, coordinator: WiiUCoordinator, name: str):
+    def __init__(self, coordinator: WiiUCoordinator, name: str) -> None:
         """Initialize the Wii U media player entity."""
         super().__init__(coordinator=coordinator)
         self.coordinator = coordinator

--- a/custom_components/nintendo_wiiu_ristretto/sensor.py
+++ b/custom_components/nintendo_wiiu_ristretto/sensor.py
@@ -4,11 +4,13 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from homeassistant.components.sensor import (
-    RestoreSensor,
     SensorDeviceClass,
+    SensorEntity,
     SensorEntityDescription,
     SensorStateClass,
 )
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 
 from .coordinator import WiiUCoordinator
 from .entity import WiiUEntity
@@ -30,12 +32,16 @@ ENTITY_DESCRIPTIONS: list[WiiUSensorEntityDescription] = [
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.BATTERY,
         value_fn=lambda entity: entity.coordinator.gamepad_battery,
-        suggested_display_precision=0
+        suggested_display_precision=0,
     )
 ]
 
 
-async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
+async def async_setup_entry(
+    hass: HomeAssistant,  # noqa: ARG001
+    config_entry: ConfigEntry,
+    async_add_entities: Callable[[list[SensorEntity]], None],
+) -> None:
     """Set up the button platform."""
     coordinator = config_entry.runtime_data
     if not isinstance(coordinator, WiiUCoordinator):
@@ -48,7 +54,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
     )
 
 
-class GenericWiiUSensor(WiiUEntity, RestoreSensor):
+class GenericWiiUSensor(WiiUEntity, SensorEntity):
     """Generic sensor for Wii U using a restore sensor."""
 
     def __init__(

--- a/custom_components/nintendo_wiiu_ristretto/translations/en.json
+++ b/custom_components/nintendo_wiiu_ristretto/translations/en.json
@@ -20,5 +20,18 @@
         "abort": {
             "already_configured": "This entry is already configured."
         }
+    },
+    "device_automation": {
+        "trigger_type": {
+            "nintendo_wiiu_ristretto.turn_on": "Device is requested to turn on"
+        }
+    },
+    "exceptions": {
+        "unhandled_trigger_type": {
+            "message": "Unhandled trigger type {trigger_type}."
+        },
+        "service_unsupported": {
+            "message": "Entity {entity} does not support this action."
+        }
     }
 }

--- a/custom_components/nintendo_wiiu_ristretto/trigger.py
+++ b/custom_components/nintendo_wiiu_ristretto/trigger.py
@@ -1,0 +1,47 @@
+"""Ristretto trigger dispatcher."""
+
+from __future__ import annotations
+
+from typing import cast
+
+from homeassistant.const import CONF_PLATFORM
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.helpers.trigger import (
+    TriggerActionType,
+    TriggerInfo,
+    TriggerProtocol,
+)
+from homeassistant.helpers.typing import ConfigType
+
+from .triggers import turn_on
+
+TRIGGERS = {
+    "turn_on": turn_on,
+}
+
+
+def _get_trigger_platform(config: ConfigType) -> TriggerProtocol:
+    """Return trigger platform."""
+    platform_split = config[CONF_PLATFORM].split(".", maxsplit=1)
+    if len(platform_split) < 2 or platform_split[1] not in TRIGGERS:
+        raise ValueError(f"Unknown Ristretto trigger platform {config[CONF_PLATFORM]}")
+    return cast(TriggerProtocol, TRIGGERS[platform_split[1]])
+
+
+async def async_validate_trigger_config(
+    hass: HomeAssistant, config: ConfigType
+) -> ConfigType:
+    """Validate config."""
+    platform = _get_trigger_platform(config)
+    return cast(ConfigType, platform.TRIGGER_SCHEMA(config))
+
+
+async def async_attach_trigger(
+    hass: HomeAssistant,
+    config: ConfigType,
+    action: TriggerActionType,
+    trigger_info: TriggerInfo,
+) -> CALLBACK_TYPE:
+    """Attach trigger of specified platform."""
+    platform = _get_trigger_platform(config)
+    return await platform.async_attach_trigger(hass, config, action, trigger_info)

--- a/custom_components/nintendo_wiiu_ristretto/trigger.py
+++ b/custom_components/nintendo_wiiu_ristretto/trigger.py
@@ -2,18 +2,20 @@
 
 from __future__ import annotations
 
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from homeassistant.const import CONF_PLATFORM
-from homeassistant.core import CALLBACK_TYPE, HomeAssistant
-from homeassistant.helpers.trigger import (
-    TriggerActionType,
-    TriggerInfo,
-    TriggerProtocol,
-)
-from homeassistant.helpers.typing import ConfigType
 
 from .triggers import turn_on
+
+if TYPE_CHECKING:
+    from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+    from homeassistant.helpers.trigger import (
+        TriggerActionType,
+        TriggerInfo,
+        TriggerProtocol,
+    )
+    from homeassistant.helpers.typing import ConfigType
 
 TRIGGERS = {
     "turn_on": turn_on,
@@ -23,17 +25,19 @@ TRIGGERS = {
 def _get_trigger_platform(config: ConfigType) -> TriggerProtocol:
     """Return trigger platform."""
     platform_split = config[CONF_PLATFORM].split(".", maxsplit=1)
-    if len(platform_split) < 2 or platform_split[1] not in TRIGGERS:
-        raise ValueError(f"Unknown Ristretto trigger platform {config[CONF_PLATFORM]}")
-    return cast(TriggerProtocol, TRIGGERS[platform_split[1]])
+    if len(platform_split) < 2 or platform_split[1] not in TRIGGERS:  # noqa: PLR2004
+        msg = f"Unknown Ristretto trigger platform {config[CONF_PLATFORM]}"
+        raise ValueError(msg)
+    return cast("TriggerProtocol", TRIGGERS[platform_split[1]])
 
 
 async def async_validate_trigger_config(
-    hass: HomeAssistant, config: ConfigType
+    hass: HomeAssistant,  # noqa: ARG001
+    config: ConfigType,
 ) -> ConfigType:
     """Validate config."""
     platform = _get_trigger_platform(config)
-    return cast(ConfigType, platform.TRIGGER_SCHEMA(config))
+    return cast("ConfigType", platform.TRIGGER_SCHEMA(config))
 
 
 async def async_attach_trigger(

--- a/custom_components/nintendo_wiiu_ristretto/triggers/__init__.py
+++ b/custom_components/nintendo_wiiu_ristretto/triggers/__init__.py
@@ -1,0 +1,1 @@
+"""Wii U Triggers."""

--- a/custom_components/nintendo_wiiu_ristretto/triggers/turn_on.py
+++ b/custom_components/nintendo_wiiu_ristretto/triggers/turn_on.py
@@ -1,0 +1,101 @@
+"""Ristretto WiiU Turn On Trigger."""
+
+from __future__ import annotations
+
+import voluptuous as vol
+from homeassistant.const import (
+    ATTR_DEVICE_ID,
+    ATTR_ENTITY_ID,
+    CONF_DEVICE_ID,
+    CONF_DOMAIN,
+    CONF_PLATFORM,
+    CONF_TYPE,
+)
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.trigger import (
+    PluggableAction,
+    TriggerInfo,
+)
+from homeassistant.helpers.typing import ConfigType
+
+from ..const import DOMAIN
+from ..helpers import (
+    async_get_device_entry_by_device_id,
+    async_get_device_id_from_entity_id,
+)
+
+# Platform type should be <DOMAIN>.<SUBMODULE_NAME>
+PLATFORM_TYPE = f"{DOMAIN}.{__name__.rsplit('.', maxsplit=1)[-1]}"
+
+TRIGGER_TYPE_TURN_ON = "turn_on"
+
+TRIGGER_SCHEMA = vol.All(
+    cv.TRIGGER_BASE_SCHEMA.extend(
+        {
+            vol.Required(CONF_PLATFORM): PLATFORM_TYPE,
+            vol.Optional(ATTR_DEVICE_ID): vol.All(cv.ensure_list, [cv.string]),
+            vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
+        },
+    ),
+    cv.has_at_least_one_key(ATTR_ENTITY_ID, ATTR_DEVICE_ID),
+)
+
+def async_get_turn_on_trigger(device_id: str) -> dict[str, str]:
+    """Return data for a turn on trigger."""
+    return {
+        CONF_PLATFORM: "device",
+        CONF_DEVICE_ID: device_id,
+        CONF_DOMAIN: DOMAIN,
+        CONF_TYPE: PLATFORM_TYPE,
+    }
+
+async def async_attach_trigger(
+    hass: HomeAssistant,
+    config: ConfigType,
+    action: PluggableAction,
+    trigger_info: TriggerInfo,
+    *,
+    platform_type: str = PLATFORM_TYPE,
+) -> CALLBACK_TYPE | None:
+    """Attach a trigger to an action."""
+    devices_ids = set()
+    if ATTR_DEVICE_ID in config:
+        devices_ids.update(config.get(ATTR_DEVICE_ID, []))
+    if ATTR_ENTITY_ID in config:
+        devices_ids.update(
+            {
+                async_get_device_id_from_entity_id(hass, entity_id)
+                for entity_id in config.get(ATTR_ENTITY_ID, [])
+            }
+        )
+    trigger_data = trigger_info["trigger_data"]
+    unsubs = []
+
+    for device_id in devices_ids:
+        device = async_get_device_entry_by_device_id(hass, device_id)
+        device_name = device.name_by_user or device.name
+
+        variables = {
+            **trigger_data,
+            CONF_PLATFORM: platform_type,
+            ATTR_DEVICE_ID: device_id,
+            "description": f"Ristretto turn on trigger for {device_name}",
+        }
+
+        turn_on_trigger = async_get_turn_on_trigger(device_id)
+
+        unsubs.append(
+            PluggableAction.async_attach_trigger(
+                hass, turn_on_trigger, action, {"trigger": variables}
+            )
+        )
+
+    @callback
+    def async_remove() -> None:
+        """Remove the trigger."""
+        for unsub in unsubs:
+            unsub()
+        unsubs.clear()
+
+    return async_remove

--- a/custom_components/nintendo_wiiu_ristretto/triggers/turn_on.py
+++ b/custom_components/nintendo_wiiu_ristretto/triggers/turn_on.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import voluptuous as vol
 from homeassistant.const import (
     ATTR_DEVICE_ID,
@@ -17,13 +19,15 @@ from homeassistant.helpers.trigger import (
     PluggableAction,
     TriggerInfo,
 )
-from homeassistant.helpers.typing import ConfigType
 
-from ..const import DOMAIN
-from ..helpers import (
+from nintendo_wiiu_ristretto.const import DOMAIN
+from nintendo_wiiu_ristretto.helpers import (
     async_get_device_entry_by_device_id,
     async_get_device_id_from_entity_id,
 )
+
+if TYPE_CHECKING:
+    from homeassistant.helpers.typing import ConfigType
 
 # Platform type should be <DOMAIN>.<SUBMODULE_NAME>
 PLATFORM_TYPE = f"{DOMAIN}.{__name__.rsplit('.', maxsplit=1)[-1]}"
@@ -41,6 +45,7 @@ TRIGGER_SCHEMA = vol.All(
     cv.has_at_least_one_key(ATTR_ENTITY_ID, ATTR_DEVICE_ID),
 )
 
+
 def async_get_turn_on_trigger(device_id: str) -> dict[str, str]:
     """Return data for a turn on trigger."""
     return {
@@ -49,6 +54,7 @@ def async_get_turn_on_trigger(device_id: str) -> dict[str, str]:
         CONF_DOMAIN: DOMAIN,
         CONF_TYPE: PLATFORM_TYPE,
     }
+
 
 async def async_attach_trigger(
     hass: HomeAssistant,


### PR DESCRIPTION
Add functionality to "turn on the Nintendo Wii U" and associated helper methods for device triggers.

Some pretty big changes here, adds the TURN_ON feature for the media player. However, this is only so you can use an automation to trigger another device to turn the Wii on like a switchbot or extra hardware.

Heavily inspired by the Samsung and WebOS TV integration in Home Assistant. 

https://www.home-assistant.io/integrations/philips_js/#turn-on-device
https://www.home-assistant.io/integrations/samsungtv/#turn-on-action
https://www.home-assistant.io/integrations/webostv/#action-turn-on
