### PR TITLE
Add documentation link to manifest.json for Nintendo Wii U component

### DIFF
--- a/custom_components/nintendo_wiiu_ristretto/manifest.json
+++ b/custom_components/nintendo_wiiu_ristretto/manifest.json
@@ -1,8 +1,8 @@
 {
     "domain": "nintendo_wiiu_ristretto",
     "name": "Nintendo Wii U (with Ristretto)",
-    "config_flow": true,
     "codeowners": [],
+    "config_flow": true,
     "dependencies": [],
     "documentation": "https://github.com/wiiu-smarthome/ha-wiiu",
     "iot_class": "local_polling",

--- a/custom_components/nintendo_wiiu_ristretto/manifest.json
+++ b/custom_components/nintendo_wiiu_ristretto/manifest.json
@@ -3,8 +3,8 @@
     "name": "Nintendo Wii U (with Ristretto)",
     "config_flow": true,
     "codeowners": [],
-    "documentation": "https://github.com/wiiu-smarthome/ha-wiiu",
     "dependencies": [],
+    "documentation": "https://github.com/wiiu-smarthome/ha-wiiu",
     "iot_class": "local_polling",
     "loggers": [
         "python_wiiu_ristretto"

--- a/custom_components/nintendo_wiiu_ristretto/manifest.json
+++ b/custom_components/nintendo_wiiu_ristretto/manifest.json
@@ -6,6 +6,7 @@
     "dependencies": [],
     "documentation": "https://github.com/wiiu-smarthome/ha-wiiu",
     "iot_class": "local_polling",
+    "issue_tracker": "https://github.com/wiiu-smarthome/ha-wiiu/issues",
     "loggers": [
         "python_wiiu_ristretto"
     ],

--- a/custom_components/nintendo_wiiu_ristretto/manifest.json
+++ b/custom_components/nintendo_wiiu_ristretto/manifest.json
@@ -3,6 +3,7 @@
     "name": "Nintendo Wii U (with Ristretto)",
     "config_flow": true,
     "codeowners": [],
+    "documentation": "https://github.com/wiiu-smarthome/ha-wiiu",
     "dependencies": [],
     "iot_class": "local_polling",
     "loggers": [


### PR DESCRIPTION
Include a link to the documentation in the manifest.json file for the Nintendo Wii U component.