### PR TITLE
Fix release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,41 +1,30 @@
-name-template: '$RESOLVED_VERSION 🌈'
-tag-template: '$RESOLVED_VERSION'
-prerelease-identifier: 'beta'
+include-pre-releases: true
 categories:
-  - title: '🛠 Breaking Changes'
+  - title: Breaking Changes 🛠
     labels:
-      - 'breaking-change'
-  - title: '🚀 Features'
+      - breaking-change
+  - title: 'New Features 🎉'
     labels:
       - 'feature'
       - 'enhancement'
-  - title: '🐛 Bug Fixes'
+  - title: 'Bug Fixes 🛠'
     labels:
       - 'fix'
       - 'bugfix'
       - 'bug'
-  - title: '👒 Dependencies and extras'
+  - title: 'Documentation'
+    labels:
+      - 'docs'
+  - title: 'Dependencies and extras 👒'
     collapse-after: 3
     labels:
       - 'chore'
       - 'dependencies'
+exclude-labels:
+  - 'ignore-for-release'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
-change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
-version-resolver:
-  major:
-    labels:
-      - 'major'
-  minor:
-    labels:
-      - 'minor'
-  patch:
-    labels:
-      - 'patch'
-  default: patch
+change-title-escapes: '\<*_&'
 autolabeler:
-  - label: 'translations'
-    files:
-      - '**/translations/*.json'
   - label: 'docs'
     branch:
       - '/docs{0,1}\/.+/'
@@ -52,8 +41,6 @@ autolabeler:
     branch:
       - '/feature\/.+/'
       - '/feat\/.+/'
-exclude-labels:
-  - 'ignore-for-release'
 template: |
   ## Changes
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -2,16 +2,9 @@ name: Release Drafter
 
 on:
   push:
-    # branches to consider in the event; optional, defaults to all
     branches:
       - main
-
-  # pull_request event is required only for autolabeler
   pull_request:
-    # Only following types are handled by the action, but one can default to all as well
-    types: [opened, reopened, synchronize]
-  # pull_request_target event is required for autolabeler to support PRs from forks
-  pull_request_target:
     types: [opened, reopened, synchronize]
 
 permissions:
@@ -20,13 +13,10 @@ permissions:
 jobs:
   update_release_draft:
     permissions:
-      # write permission is required to create a github release
       contents: write
-      # write permission is required for autolabeler
-      # otherwise, read permission is required at least
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@v6.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
At the moment, release drafter seems to like to create a whole new release for some reason on each PR, commit etc so release management gets messy.

I've just copied the config from one of my existing repos which is working https://github.com/pantherale0/pynintendoparental